### PR TITLE
[TECH] Sort alphabetically and add SpaceAroundMethodCallOperator

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,17 +11,13 @@ Layout/ArgumentAlignment:
 
 Layout/CaseIndentation:
   EnforcedStyle: end
-  
+
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
 Layout/FirstHashElementIndentation:
   Enabled: false
-  
-Layout/HashAlignment:
-  Enabled: true
-  EnforcedLastArgumentHashStyle: always_ignore
-  
+
 Layout/LineLength:
   Enabled: false
 
@@ -30,16 +26,15 @@ Layout/MultilineMethodCallIndentation:
 
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
-  
+
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
-  
+
 Layout/SpaceInsideHashLiteralBraces:
-  Enabled: false
+  EnforcedStyle: compact
 
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
-  EnforcedStyle: indent
 
 Metrics/AbcSize:
   Max: 20
@@ -56,36 +51,31 @@ Metrics/ModuleLength:
 
 Metrics/MethodLength:
   Max: 15
-  
+
 Naming/RescuedExceptionsVariableName:
   PreferredName: exception
 
 Style/AsciiComments:
   Enabled: false
 
-Style/BlockDelimiters:
-  Exclude:
-    - spec/**/*_spec.rb
-    
 Style/CollectionMethods:
   Enabled: true
   PreferredMethods:
     inject: 'inject'
-    
+
 Style/Documentation:
   Enabled: false
 
-Style/FormatString:
+Style/GuardClause:
   Enabled: false
 
-Style/GuardClause:
+Style/FormatString:
   Enabled: false
 
 Style/FormatStringToken:
   EnforcedStyle: template
 
 Style/FrozenStringLiteralComment:
-  EnforcedStyle: always
   SupportedStyles:
     - always
 
@@ -96,7 +86,7 @@ Style/IfUnlessModifier:
   Enabled: false
 
 Style/Lambda:
-  Enabled: false
+  EnforcedStyle: literal
 
 Style/RaiseArgs:
   Enabled: false
@@ -108,14 +98,8 @@ Style/RegexpLiteral:
   EnforcedStyle: slashes
   AllowInnerSlashes: true
 
-Style/SignalException:
-  Enabled: false
-
 Style/SingleLineBlockParams:
   Enabled: false
 
-Style/TrivialAccessors:
-  AllowPredicates: true
-  
 Style/WordArray:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,18 +9,19 @@ AllCops:
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 
-Layout/ParameterAlignment:
-  EnforcedStyle: with_fixed_indentation
-
 Layout/CaseIndentation:
   EnforcedStyle: end
+  
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
 
 Layout/FirstHashElementIndentation:
   Enabled: false
-
-Layout/SpaceInsideHashLiteralBraces:
-  Enabled: false
-
+  
+Layout/HashAlignment:
+  Enabled: true
+  EnforcedLastArgumentHashStyle: always_ignore
+  
 Layout/LineLength:
   Enabled: false
 
@@ -29,43 +30,16 @@ Layout/MultilineMethodCallIndentation:
 
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
+  
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
+  
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: false
 
-Layout/HashAlignment:
+Layout/SpaceAroundMethodCallOperator:
   Enabled: true
-  EnforcedLastArgumentHashStyle: always_ignore
-
-Layout/EndAlignment:
-  EnforcedStyleAlignWith: variable
-
-Style/AsciiComments:
-  Enabled: false
-
-Style/CollectionMethods:
-  Enabled: true
-  PreferredMethods:
-    inject: 'inject'
-
-Style/Documentation:
-  Enabled: false
-
-Style/BlockDelimiters:
-  Exclude:
-    - spec/**/*_spec.rb
-
-Style/GuardClause:
-  Enabled: false
-
-Style/IfUnlessModifier:
-  Enabled: false
-
-Style/Lambda:
-  Enabled: false
-
-Style/RaiseArgs:
-  Enabled: false
-
-Style/SignalException:
-  Enabled: false
+  EnforcedStyle: indent
 
 Metrics/AbcSize:
   Max: 20
@@ -83,16 +57,45 @@ Metrics/ModuleLength:
 Metrics/MethodLength:
   Max: 15
 
-Style/SingleLineBlockParams:
+Style/AsciiComments:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Exclude:
+    - spec/**/*_spec.rb
+    
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    inject: 'inject'
+    
+Style/Documentation:
   Enabled: false
 
 Style/FormatString:
   Enabled: false
 
+Style/GuardClause:
+  Enabled: false
+
 Style/FormatStringToken:
   EnforcedStyle: template
 
-Style/WordArray:
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+  SupportedStyles:
+    - always
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/Lambda:
+  Enabled: false
+
+Style/RaiseArgs:
   Enabled: false
 
 Style/RedundantSelf:
@@ -102,11 +105,14 @@ Style/RegexpLiteral:
   EnforcedStyle: slashes
   AllowInnerSlashes: true
 
+Style/SignalException:
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false
+
 Style/TrivialAccessors:
   AllowPredicates: true
-
-Style/FrozenStringLiteralComment:
-  EnforcedStyle: always
-  SupportedStyles:
-    - always
-
+  
+Style/WordArray:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,9 @@ Metrics/ModuleLength:
 
 Metrics/MethodLength:
   Max: 15
+  
+Naming/RescuedExceptionsVariableName:
+  PreferredName: exception
 
 Style/AsciiComments:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Layout/FirstHashElementIndentation:
   Enabled: false
 
 Layout/LineLength:
-  Enabled: false
+  Max: 120
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented


### PR DESCRIPTION
They are ordered alphabetically and a new method was added that was marked as pending in the rubocop default (SpaceAroundMethodCallOperator)