### PR TITLE
Add linter SpaceInsideStringInterpolation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,9 @@ Layout/MultilineOperationIndentation:
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
+Layout/SpaceInsideStringInterpolation:
+  EnforcedStyle: space
+
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: compact
 


### PR DESCRIPTION
Changes made taking into account the following comments:
https://github.com/monokera-tech/automation-tests/pull/9#discussion_r424446295

EnforcedStyle: space
# bad
   var = "This is the #{no_space} example"

# good
   var = "This is the #{ space } example"