### PR TITLE
🔧 SEG-001: Update ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2
   Exclude:
     - 'bin/**/*'
     - 'db/**/*'
@@ -82,7 +82,7 @@ Style/FormatString:
   Enabled: false
 
 Style/FormatStringToken:
-  EnforcedStyle: template
+  Enabled: false
 
 Style/FrozenStringLiteralComment:
   SupportedStyles:


### PR DESCRIPTION
update ruby version target from 2.7 to 3.2.

disable FormatStringToken because the policy number creation sequential was omitted, however rubocop suggests removing that omission and then says to change this method, but the suggested options do not correspond to what you want to do.