### PR TITLE
✨ SEG-001: Clean the rubocop output for pre push

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 AllCops:
   TargetRubyVersion: 3.2
+  NewCops: disable
+  SuggestExtensions: false
   Exclude:
     - 'bin/**/*'
     - 'db/**/*'


### PR DESCRIPTION
The purpose of this PR is add the configuration to clean the output of rubocop and create a tidy prepush

`from this:
`
<img width="1431" alt="image" src="https://github.com/monokera-tech/linters/assets/23710544/47e8103a-b43e-4410-9088-5bcdb4674462">

`to this:`
<img width="1094" alt="image" src="https://github.com/monokera-tech/linters/assets/23710544/f4d0a70a-3a57-48b5-831c-9c77de801563">