### PR TITLE
✨ FSC-001: Allow using versioning numbers in variables and symbols

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,8 @@ Naming/RescuedExceptionsVariableName:
 
 Naming/VariableNumber:
   EnforcedStyle: snake_case
+  AllowedPatterns:
+    - _v\d+\z
 
 Style/AsciiComments:
   Enabled: false


### PR DESCRIPTION
## Changes

Include pattern to allow variables and symbols with a version-like format

e.g. we can now user `api_v2` instead of `api_v_2`